### PR TITLE
[Keymap] Helix default keymap oled update

### DIFF
--- a/keyboards/helix/rev2/config.h
+++ b/keyboards/helix/rev2/config.h
@@ -48,6 +48,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   #define SSD1306OLED
 #endif
 
+#define OLED_UPDATE_INTERVAL 50
+
 /* Select rows configuration */
 // Rows are 4 or 5
 // #define HELIX_ROWS 5 see ./rules.mk

--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -495,19 +495,34 @@ void music_scale_user(void)
 
 
 //SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
-#ifdef SSD1306OLED
+#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
 
+#    if defined(OLED_DRIVER_ENABLE)
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    if (is_keyboard_master()) {
+        return OLED_ROTATION_0;
+    } else {
+        return OLED_ROTATION_180;
+    }
+}
+#    else
+#        define oled_write(data,flag)    matrix_write(matrix, data)
+#        define oled_write_P(data,flag)  matrix_write_P(matrix, data)
+#    endif
+
+#    ifdef SSD1306OLED
 void matrix_scan_user(void) {
-     iota_gfx_task();  // this is what updates the display continuously
+    iota_gfx_task();  // this is what updates the display continuously
 }
 
 void matrix_update(struct CharacterMatrix *dest,
-                          const struct CharacterMatrix *source) {
-  if (memcmp(dest->display, source->display, sizeof(dest->display))) {
-    memcpy(dest->display, source->display, sizeof(dest->display));
-    dest->dirty = true;
-  }
+                   const struct CharacterMatrix *source) {
+    if (memcmp(dest->display, source->display, sizeof(dest->display))) {
+        memcpy(dest->display, source->display, sizeof(dest->display));
+        dest->dirty = true;
+    }
 }
+#    endif
 
 //assign the right code to your layers for OLED display
 #define L_BASE 0
@@ -516,108 +531,148 @@ void matrix_update(struct CharacterMatrix *dest,
 #define L_ADJUST (1<<_ADJUST)
 #define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
 
+#    ifdef SSD1306OLED
 static void render_logo(struct CharacterMatrix *matrix) {
+#    else
+static void render_logo(void) {
+#    endif
 
-  static const char helix_logo[] PROGMEM ={
-    0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
-    0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
-    0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
-    0};
-  matrix_write_P(matrix, helix_logo);
-  //matrix_write_P(&matrix, PSTR(" Split keyboard kit"));
+    static const char helix_logo[] PROGMEM ={
+        0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
+        0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
+        0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
+        0};
+    oled_write_P(helix_logo, false);
 }
 
+#    ifdef SSD1306OLED
 static void render_rgbled_status(bool full, struct CharacterMatrix *matrix) {
-#ifdef RGBLIGHT_ENABLE
-  char buf[30];
-  if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
-      if (full) {
-          snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
-                   rgblight_get_mode(),
-                   rgblight_get_hue()/RGBLIGHT_HUE_STEP,
-                   rgblight_get_sat()/RGBLIGHT_SAT_STEP,
-                   rgblight_get_val()/RGBLIGHT_VAL_STEP);
-      } else {
-          snprintf(buf, sizeof(buf), "[%2d] ",rgblight_get_mode());
-      }
-      matrix_write(matrix, buf);
-  }
-#endif
+#    else
+static void render_rgbled_status(bool full) {
+#    endif
+#    ifdef RGBLIGHT_ENABLE
+    char buf[30];
+    if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
+        if (full) {
+            snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
+                     rgblight_get_mode(),
+                     rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                     rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                     rgblight_get_val()/RGBLIGHT_VAL_STEP);
+        } else {
+            snprintf(buf, sizeof(buf), "[%2d] ", rgblight_get_mode());
+        }
+        oled_write(buf, false);
+    }
+#    endif
 }
 
+#    ifdef SSD1306OLED
 static void render_layer_status(struct CharacterMatrix *matrix) {
+#    else
+static void render_layer_status(void) {
+#    endif
   // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
-  char buf[10];
-  matrix_write_P(matrix, PSTR("Layer: "));
+    char buf[10];
+    oled_write_P(PSTR("Layer: "), false);
     switch (layer_state) {
-        case L_BASE:
-           matrix_write_P(matrix, PSTR("Default"));
-           break;
-        case L_RAISE:
-           matrix_write_P(matrix, PSTR("Raise"));
-           break;
-        case L_LOWER:
-           matrix_write_P(matrix, PSTR("Lower"));
-           break;
-        case L_ADJUST:
-        case L_ADJUST_TRI:
-           matrix_write_P(matrix, PSTR("Adjust"));
-           break;
-        default:
-           matrix_write_P(matrix, PSTR("Undef-"));
-           snprintf(buf,sizeof(buf), "%ld", layer_state);
-           matrix_write(matrix, buf);
+    case L_BASE:
+        oled_write_P(PSTR("Default"), false);
+        break;
+    case L_RAISE:
+        oled_write_P(PSTR("Raise"), false);
+        break;
+    case L_LOWER:
+        oled_write_P(PSTR("Lower"), false);
+        break;
+    case L_ADJUST:
+    case L_ADJUST_TRI:
+        oled_write_P(PSTR("Adjust"), false);
+        break;
+    default:
+        oled_write_P(PSTR("Undef-"), false);
+        snprintf(buf,sizeof(buf), "%ld", layer_state);
+        oled_write(buf, false);
     }
 }
 
+#    ifdef SSD1306OLED
 void render_status(struct CharacterMatrix *matrix) {
-
+#    else
+void render_status(void) {
+#    endif
   // Render to mode icon
-  static const char os_logo[][2][3] PROGMEM  ={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
-  if (is_mac_mode()) {
-    matrix_write_P(matrix, os_logo[0][0]);
-    matrix_write_P(matrix, PSTR("\n"));
-    matrix_write_P(matrix, os_logo[0][1]);
-  } else {
-    matrix_write_P(matrix, os_logo[1][0]);
-    matrix_write_P(matrix, PSTR("\n"));
-    matrix_write_P(matrix, os_logo[1][1]);
-  }
+    static const char os_logo[][2][3] PROGMEM = {{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+    if (is_mac_mode()) {
+        oled_write_P(os_logo[0][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write_P(os_logo[0][1], false);
+    } else {
+        oled_write_P(os_logo[1][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write_P(os_logo[1][1], false);
+    }
 
-  matrix_write_P(matrix, PSTR(" "));
-  render_layer_status(matrix);
-  matrix_write_P(matrix, PSTR("\n"));
+    oled_write_P(PSTR(" "), false);
+#    ifdef SSD1306OLED
+    render_layer_status(matrix);
+#    else
+    render_layer_status();
+#    endif
+    oled_write_P(PSTR("\n"), false);
 
-  // Host Keyboard LED Status
-  matrix_write_P(matrix, (host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ?
-                 PSTR("NUMLOCK") : PSTR("       "));
-  matrix_write_P(matrix, (host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ?
-                 PSTR("CAPS") : PSTR("    "));
-  matrix_write_P(matrix, (host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ?
-                 PSTR("SCLK") : PSTR("    "));
-  matrix_write_P(matrix, PSTR("\n"));
-  render_rgbled_status(true, matrix);
+    // Host Keyboard LED Status
+    oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ?
+                 PSTR("NUMLOCK") : PSTR("       "), false);
+    oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ?
+                 PSTR("CAPS") : PSTR("    "), false);
+    oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ?
+                 PSTR("SCLK") : PSTR("    "), false);
+    oled_write_P(PSTR("\n"), false);
+#    ifdef SSD1306OLED
+    render_rgbled_status(true, matrix);
+#    else
+    render_rgbled_status(true);
+#    endif
 }
 
 
+#    ifdef SSD1306OLED
 void iota_gfx_task_user(void) {
-  struct CharacterMatrix matrix;
+    struct CharacterMatrix matrix;
 
-#if DEBUG_TO_SCREEN
-  if (debug_enable) {
-    return;
-  }
-#endif
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
 
-  matrix_clear(&matrix);
-  if(is_master){
-    render_status(&matrix);
-  }else{
-    render_logo(&matrix);
-    render_rgbled_status(false, &matrix);
-    render_layer_status(&matrix);
-  }
-  matrix_update(&display, &matrix);
+    matrix_clear(&matrix);
+    if (is_keyboard_master()) {
+        render_status(&matrix);
+    } else {
+        render_logo(&matrix);
+        render_rgbled_status(false, &matrix);
+        render_layer_status(&matrix);
+    }
+    matrix_update(&display, &matrix);
 }
+#    else
+void oled_task_user(void) {
 
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    if (is_keyboard_master()) {
+        render_status();
+    } else {
+        render_logo();
+        render_rgbled_status(false);
+        render_layer_status();
+    }
+}
+#    endif
 #endif

--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -11,14 +11,6 @@
   #include "ssd1306.h"
 #endif
 
-
-#ifdef RGBLIGHT_ENABLE
-//Following line allows macro to read current RGB settings
-extern rgblight_config_t rgblight_config;
-#endif
-
-extern uint8_t is_master;
-
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
 // The underscores don't mean anything - you can have a layer called STUFF or any other name.
 // Layer names don't all need to be of the same length, obviously, and you can also skip them
@@ -420,7 +412,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         if (record->event.pressed) {
           rgblight_mode(RGB_current_mode);
           rgblight_step();
-          RGB_current_mode = rgblight_config.mode;
+          RGB_current_mode = rgblight_get_mode();
         }
       #endif
       return false;
@@ -454,7 +446,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         if (record->event.pressed) {
           eeconfig_update_rgblight_default();
           rgblight_enable();
-          RGB_current_mode = rgblight_config.mode;
+          RGB_current_mode = rgblight_get_mode();
         }
       #endif
       break;
@@ -467,7 +459,7 @@ void matrix_init_user(void) {
         startup_user();
     #endif
     #ifdef RGBLIGHT_ENABLE
-      RGB_current_mode = rgblight_config.mode;
+      RGB_current_mode = rgblight_get_mode();
     #endif
     //SSD1306 OLED init, make sure to add #define SSD1306OLED in config.h
     #ifdef SSD1306OLED
@@ -538,15 +530,15 @@ static void render_logo(struct CharacterMatrix *matrix) {
 static void render_rgbled_status(bool full, struct CharacterMatrix *matrix) {
 #ifdef RGBLIGHT_ENABLE
   char buf[30];
-  if (RGBLIGHT_MODES > 1 && rgblight_config.enable) {
+  if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
       if (full) {
           snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
-                   rgblight_config.mode,
-                   rgblight_config.hue/RGBLIGHT_HUE_STEP,
-                   rgblight_config.sat/RGBLIGHT_SAT_STEP,
-                   rgblight_config.val/RGBLIGHT_VAL_STEP);
+                   rgblight_get_mode(),
+                   rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                   rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                   rgblight_get_val()/RGBLIGHT_VAL_STEP);
       } else {
-          snprintf(buf, sizeof(buf), "[%2d] ",rgblight_config.mode);
+          snprintf(buf, sizeof(buf), "[%2d] ",rgblight_get_mode());
       }
       matrix_write(matrix, buf);
   }

--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -427,9 +427,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       break;
     case EISU:
       if (record->event.pressed) {
-        if(keymap_config.swap_lalt_lgui==false){
+        if (is_mac_mode()) {
           register_code(KC_LANG2);
-        }else{
+        } else {
           SEND_STRING(SS_LALT("`"));
         }
       } else {
@@ -439,9 +439,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
       break;
     case KANA:
       if (record->event.pressed) {
-        if(keymap_config.swap_lalt_lgui==false){
+        if (is_mac_mode()) {
           register_code(KC_LANG1);
-        }else{
+        } else {
           SEND_STRING(SS_LALT("`"));
         }
       } else {
@@ -582,11 +582,11 @@ void render_status(struct CharacterMatrix *matrix) {
 
   // Render to mode icon
   static const char os_logo[][2][3] PROGMEM  ={{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
-  if(keymap_config.swap_lalt_lgui==false){
+  if (is_mac_mode()) {
     matrix_write_P(matrix, os_logo[0][0]);
     matrix_write_P(matrix, PSTR("\n"));
     matrix_write_P(matrix, os_logo[0][1]);
-  }else{
+  } else {
     matrix_write_P(matrix, os_logo[1][0]);
     matrix_write_P(matrix, PSTR("\n"));
     matrix_write_P(matrix, os_logo[1][1]);

--- a/keyboards/helix/rev2/keymaps/default/keymap.c
+++ b/keyboards/helix/rev2/keymaps/default/keymap.c
@@ -1,3 +1,19 @@
+/* Copyright 2020 yushakobo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include QMK_KEYBOARD_H
 #include "bootloader.h"
 #ifdef PROTOCOL_LUFA
@@ -6,9 +22,6 @@
 #endif
 #ifdef AUDIO_ENABLE
   #include "audio.h"
-#endif
-#ifdef SSD1306OLED
-  #include "ssd1306.h"
 #endif
 
 // Each layer gets a name for readability, which is then used in the keymap matrix below.
@@ -454,6 +467,10 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
+#ifdef SSD1306OLED
+  #include "ssd1306.h"
+#endif
+
 void matrix_init_user(void) {
     #ifdef AUDIO_ENABLE
         startup_user();
@@ -491,188 +508,4 @@ void music_scale_user(void)
     PLAY_SONG(music_scale);
 }
 
-#endif
-
-
-//SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
-#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
-
-#    if defined(OLED_DRIVER_ENABLE)
-oled_rotation_t oled_init_user(oled_rotation_t rotation) {
-    if (is_keyboard_master()) {
-        return OLED_ROTATION_0;
-    } else {
-        return OLED_ROTATION_180;
-    }
-}
-#    else
-#        define oled_write(data,flag)    matrix_write(matrix, data)
-#        define oled_write_P(data,flag)  matrix_write_P(matrix, data)
-#    endif
-
-#    ifdef SSD1306OLED
-void matrix_scan_user(void) {
-    iota_gfx_task();  // this is what updates the display continuously
-}
-
-void matrix_update(struct CharacterMatrix *dest,
-                   const struct CharacterMatrix *source) {
-    if (memcmp(dest->display, source->display, sizeof(dest->display))) {
-        memcpy(dest->display, source->display, sizeof(dest->display));
-        dest->dirty = true;
-    }
-}
-#    endif
-
-//assign the right code to your layers for OLED display
-#define L_BASE 0
-#define L_LOWER (1<<_LOWER)
-#define L_RAISE (1<<_RAISE)
-#define L_ADJUST (1<<_ADJUST)
-#define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
-
-#    ifdef SSD1306OLED
-static void render_logo(struct CharacterMatrix *matrix) {
-#    else
-static void render_logo(void) {
-#    endif
-
-    static const char helix_logo[] PROGMEM ={
-        0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
-        0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
-        0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
-        0};
-    oled_write_P(helix_logo, false);
-}
-
-#    ifdef SSD1306OLED
-static void render_rgbled_status(bool full, struct CharacterMatrix *matrix) {
-#    else
-static void render_rgbled_status(bool full) {
-#    endif
-#    ifdef RGBLIGHT_ENABLE
-    char buf[30];
-    if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
-        if (full) {
-            snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
-                     rgblight_get_mode(),
-                     rgblight_get_hue()/RGBLIGHT_HUE_STEP,
-                     rgblight_get_sat()/RGBLIGHT_SAT_STEP,
-                     rgblight_get_val()/RGBLIGHT_VAL_STEP);
-        } else {
-            snprintf(buf, sizeof(buf), "[%2d] ", rgblight_get_mode());
-        }
-        oled_write(buf, false);
-    }
-#    endif
-}
-
-#    ifdef SSD1306OLED
-static void render_layer_status(struct CharacterMatrix *matrix) {
-#    else
-static void render_layer_status(void) {
-#    endif
-  // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
-    char buf[10];
-    oled_write_P(PSTR("Layer: "), false);
-    switch (layer_state) {
-    case L_BASE:
-        oled_write_P(PSTR("Default"), false);
-        break;
-    case L_RAISE:
-        oled_write_P(PSTR("Raise"), false);
-        break;
-    case L_LOWER:
-        oled_write_P(PSTR("Lower"), false);
-        break;
-    case L_ADJUST:
-    case L_ADJUST_TRI:
-        oled_write_P(PSTR("Adjust"), false);
-        break;
-    default:
-        oled_write_P(PSTR("Undef-"), false);
-        snprintf(buf,sizeof(buf), "%ld", layer_state);
-        oled_write(buf, false);
-    }
-}
-
-#    ifdef SSD1306OLED
-void render_status(struct CharacterMatrix *matrix) {
-#    else
-void render_status(void) {
-#    endif
-  // Render to mode icon
-    static const char os_logo[][2][3] PROGMEM = {{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
-    if (is_mac_mode()) {
-        oled_write_P(os_logo[0][0], false);
-        oled_write_P(PSTR("\n"), false);
-        oled_write_P(os_logo[0][1], false);
-    } else {
-        oled_write_P(os_logo[1][0], false);
-        oled_write_P(PSTR("\n"), false);
-        oled_write_P(os_logo[1][1], false);
-    }
-
-    oled_write_P(PSTR(" "), false);
-#    ifdef SSD1306OLED
-    render_layer_status(matrix);
-#    else
-    render_layer_status();
-#    endif
-    oled_write_P(PSTR("\n"), false);
-
-    // Host Keyboard LED Status
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ?
-                 PSTR("NUMLOCK") : PSTR("       "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ?
-                 PSTR("CAPS") : PSTR("    "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ?
-                 PSTR("SCLK") : PSTR("    "), false);
-    oled_write_P(PSTR("\n"), false);
-#    ifdef SSD1306OLED
-    render_rgbled_status(true, matrix);
-#    else
-    render_rgbled_status(true);
-#    endif
-}
-
-
-#    ifdef SSD1306OLED
-void iota_gfx_task_user(void) {
-    struct CharacterMatrix matrix;
-
-#        if DEBUG_TO_SCREEN
-    if (debug_enable) {
-        return;
-    }
-#        endif
-
-    matrix_clear(&matrix);
-    if (is_keyboard_master()) {
-        render_status(&matrix);
-    } else {
-        render_logo(&matrix);
-        render_rgbled_status(false, &matrix);
-        render_layer_status(&matrix);
-    }
-    matrix_update(&display, &matrix);
-}
-#    else
-void oled_task_user(void) {
-
-#        if DEBUG_TO_SCREEN
-    if (debug_enable) {
-        return;
-    }
-#        endif
-
-    if (is_keyboard_master()) {
-        render_status();
-    } else {
-        render_logo();
-        render_rgbled_status(false);
-        render_layer_status();
-    }
-}
-#    endif
 #endif

--- a/keyboards/helix/rev2/keymaps/default/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/default/oled_display.c
@@ -1,0 +1,219 @@
+/* Copyright 2020 yushakobo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include QMK_KEYBOARD_H
+
+#ifdef SSD1306OLED
+  #include "ssd1306.h"
+#endif
+
+// Each layer gets a name for readability, which is then used in the keymap matrix below.
+// The underscores don't mean anything - you can have a layer called STUFF or any other name.
+// Layer names don't all need to be of the same length, obviously, and you can also skip them
+// entirely and just use numbers.
+enum layer_number {
+    _QWERTY = 0,
+    _COLEMAK,
+    _DVORAK,
+    _LOWER,
+    _RAISE,
+    _ADJUST
+};
+
+//SSD1306 OLED update loop, make sure to add #define SSD1306OLED in config.h
+#if defined(SSD1306OLED) || defined(OLED_DRIVER_ENABLE)
+
+#    if defined(OLED_DRIVER_ENABLE)
+oled_rotation_t oled_init_user(oled_rotation_t rotation) {
+    if (is_keyboard_master()) {
+        return OLED_ROTATION_0;
+    } else {
+        return OLED_ROTATION_180;
+    }
+}
+#    else
+#        define oled_write(data,flag)    matrix_write(matrix, data)
+#        define oled_write_P(data,flag)  matrix_write_P(matrix, data)
+#    endif
+
+#    ifdef SSD1306OLED
+void matrix_scan_user(void) {
+    iota_gfx_task();  // this is what updates the display continuously
+}
+
+void matrix_update(struct CharacterMatrix *dest,
+                   const struct CharacterMatrix *source) {
+    if (memcmp(dest->display, source->display, sizeof(dest->display))) {
+        memcpy(dest->display, source->display, sizeof(dest->display));
+        dest->dirty = true;
+    }
+}
+#    endif
+
+//assign the right code to your layers for OLED display
+#define L_BASE 0
+#define L_LOWER (1<<_LOWER)
+#define L_RAISE (1<<_RAISE)
+#define L_ADJUST (1<<_ADJUST)
+#define L_ADJUST_TRI (L_ADJUST|L_RAISE|L_LOWER)
+
+#    ifdef SSD1306OLED
+static void render_logo(struct CharacterMatrix *matrix) {
+#    else
+static void render_logo(void) {
+#    endif
+
+    static const char helix_logo[] PROGMEM ={
+        0x80,0x81,0x82,0x83,0x84,0x85,0x86,0x87,0x88,0x89,0x8a,0x8b,0x8c,0x8d,0x8e,0x8f,0x90,0x91,0x92,0x93,0x94,
+        0xa0,0xa1,0xa2,0xa3,0xa4,0xa5,0xa6,0xa7,0xa8,0xa9,0xaa,0xab,0xac,0xad,0xae,0xaf,0xb0,0xb1,0xb2,0xb3,0xb4,
+        0xc0,0xc1,0xc2,0xc3,0xc4,0xc5,0xc6,0xc7,0xc8,0xc9,0xca,0xcb,0xcc,0xcd,0xce,0xcf,0xd0,0xd1,0xd2,0xd3,0xd4,
+        0};
+    oled_write_P(helix_logo, false);
+}
+
+#    ifdef SSD1306OLED
+static void render_rgbled_status(bool full, struct CharacterMatrix *matrix) {
+#    else
+static void render_rgbled_status(bool full) {
+#    endif
+#    ifdef RGBLIGHT_ENABLE
+    char buf[30];
+    if (RGBLIGHT_MODES > 1 && rgblight_is_enabled()) {
+        if (full) {
+            snprintf(buf, sizeof(buf), " LED %2d: %d,%d,%d ",
+                     rgblight_get_mode(),
+                     rgblight_get_hue()/RGBLIGHT_HUE_STEP,
+                     rgblight_get_sat()/RGBLIGHT_SAT_STEP,
+                     rgblight_get_val()/RGBLIGHT_VAL_STEP);
+        } else {
+            snprintf(buf, sizeof(buf), "[%2d] ", rgblight_get_mode());
+        }
+        oled_write(buf, false);
+    }
+#    endif
+}
+
+#    ifdef SSD1306OLED
+static void render_layer_status(struct CharacterMatrix *matrix) {
+#    else
+static void render_layer_status(void) {
+#    endif
+  // Define layers here, Have not worked out how to have text displayed for each layer. Copy down the number you see and add a case for it below
+    char buf[10];
+    oled_write_P(PSTR("Layer: "), false);
+    switch (layer_state) {
+    case L_BASE:
+        oled_write_P(PSTR("Default"), false);
+        break;
+    case L_RAISE:
+        oled_write_P(PSTR("Raise"), false);
+        break;
+    case L_LOWER:
+        oled_write_P(PSTR("Lower"), false);
+        break;
+    case L_ADJUST:
+    case L_ADJUST_TRI:
+        oled_write_P(PSTR("Adjust"), false);
+        break;
+    default:
+        oled_write_P(PSTR("Undef-"), false);
+        snprintf(buf,sizeof(buf), "%ld", layer_state);
+        oled_write(buf, false);
+    }
+}
+
+#    ifdef SSD1306OLED
+void render_status(struct CharacterMatrix *matrix) {
+#    else
+void render_status(void) {
+#    endif
+  // Render to mode icon
+    static const char os_logo[][2][3] PROGMEM = {{{0x95,0x96,0},{0xb5,0xb6,0}},{{0x97,0x98,0},{0xb7,0xb8,0}}};
+    if (is_mac_mode()) {
+        oled_write_P(os_logo[0][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write_P(os_logo[0][1], false);
+    } else {
+        oled_write_P(os_logo[1][0], false);
+        oled_write_P(PSTR("\n"), false);
+        oled_write_P(os_logo[1][1], false);
+    }
+
+    oled_write_P(PSTR(" "), false);
+#    ifdef SSD1306OLED
+    render_layer_status(matrix);
+#    else
+    render_layer_status();
+#    endif
+    oled_write_P(PSTR("\n"), false);
+
+    // Host Keyboard LED Status
+    oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ?
+                 PSTR("NUMLOCK") : PSTR("       "), false);
+    oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ?
+                 PSTR("CAPS") : PSTR("    "), false);
+    oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ?
+                 PSTR("SCLK") : PSTR("    "), false);
+    oled_write_P(PSTR("\n"), false);
+#    ifdef SSD1306OLED
+    render_rgbled_status(true, matrix);
+#    else
+    render_rgbled_status(true);
+#    endif
+}
+
+
+#    ifdef SSD1306OLED
+void iota_gfx_task_user(void) {
+    struct CharacterMatrix matrix;
+
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    matrix_clear(&matrix);
+    if (is_keyboard_master()) {
+        render_status(&matrix);
+    } else {
+        render_logo(&matrix);
+        render_rgbled_status(false, &matrix);
+        render_layer_status(&matrix);
+    }
+    matrix_update(&display, &matrix);
+}
+#    else
+void oled_task_user(void) {
+
+#        if DEBUG_TO_SCREEN
+    if (debug_enable) {
+        return;
+    }
+#        endif
+
+    if (is_keyboard_master()) {
+        render_status();
+    } else {
+        render_logo();
+        render_rgbled_status(false);
+        render_layer_status();
+    }
+}
+#    endif
+#endif

--- a/keyboards/helix/rev2/keymaps/default/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/default/oled_display.c
@@ -178,6 +178,10 @@ void render_status(void) {
 
 
 #    ifdef SSD1306OLED
+#        if OLED_UPDATE_INTERVAL > 0
+uint16_t oled_update_timeout;
+#        endif
+
 void iota_gfx_task_user(void) {
     struct CharacterMatrix matrix;
 
@@ -187,6 +191,12 @@ void iota_gfx_task_user(void) {
     }
 #        endif
 
+#if      OLED_UPDATE_INTERVAL > 0
+    if (timer_elapsed(oled_update_timeout) < OLED_UPDATE_INTERVAL) {
+        return;
+    }
+    oled_update_timeout = timer_read();
+#endif
     matrix_clear(&matrix);
     if (is_keyboard_master()) {
         render_status(&matrix);

--- a/keyboards/helix/rev2/keymaps/default/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/default/oled_display.c
@@ -163,17 +163,16 @@ void render_status(void) {
     oled_write_P(PSTR("\n"), false);
 
     // Host Keyboard LED Status
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_NUM_LOCK)) ?
-                 PSTR("NUMLOCK") : PSTR("       "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_CAPS_LOCK)) ?
-                 PSTR("CAPS") : PSTR("    "), false);
-    oled_write_P((host_keyboard_leds() & (1<<USB_LED_SCROLL_LOCK)) ?
-                 PSTR("SCLK") : PSTR("    "), false);
+    led_t led_state = host_keyboard_led_state();
+    oled_write_P(led_state.num_lock ? PSTR("NUMLOCK") : PSTR("       "), false);
+    oled_write_P(led_state.caps_lock ? PSTR("CAPS") : PSTR("    "), false);
+    oled_write_P(led_state.scroll_lock ? PSTR("SCLK") : PSTR("    "), false);
     oled_write_P(PSTR("\n"), false);
 #    ifdef SSD1306OLED
     render_rgbled_status(true, matrix);
 #    else
     render_rgbled_status(true);
+    oled_write_P(PSTR("\n"), false);
 #    endif
 }
 

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -18,6 +18,14 @@ LTO_ENABLE = no  # if firmware size over limit, try this option
 # LED_ANIMATIONS = yes        # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
+# OLED_ENABLE が yes のとき
+#   OLED_SELECT が core ならば QMK 標準の oled_dirver.c を使用します。
+#   OLED_SELECT が core 以外ならば従来どおり helix/local_drivers/ssd1306.c を使用します。
+# If OLED_ENABLE is 'yes'
+#   If OLED_SELECT is 'core', use QMK standard oled_dirver.c.
+#   If OLED_SELECT is other than 'core', use helix/local_drivers/ssd1306.c.
+OLED_SELECT = core
+
 # convert Helix-specific options (that represent combinations of standard options)
 #   into QMK standard options.
 include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/default/rules.mk
+++ b/keyboards/helix/rev2/keymaps/default/rules.mk
@@ -26,6 +26,10 @@ LTO_ENABLE = no  # if firmware size over limit, try this option
 #   If OLED_SELECT is other than 'core', use helix/local_drivers/ssd1306.c.
 OLED_SELECT = core
 
+ifeq ($(strip $(OLED_ENABLE)), yes)
+    SRC += oled_display.c
+endif
+
 # convert Helix-specific options (that represent combinations of standard options)
 #   into QMK standard options.
 include $(strip $(KEYBOARD_LOCAL_FEATURES_MK))

--- a/keyboards/helix/rev2/keymaps/led_test/oled_display.c
+++ b/keyboards/helix/rev2/keymaps/led_test/oled_display.c
@@ -1,0 +1,1 @@
+#include "../default/oled_display.c"

--- a/keyboards/helix/rev2/keymaps/led_test/rules.mk
+++ b/keyboards/helix/rev2/keymaps/led_test/rules.mk
@@ -18,6 +18,10 @@ LED_UNDERGLOW_ENABLE = no    # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes         # LED animations
 # IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
 
+OLED_SELECT = core
+ifeq ($(strip $(OLED_ENABLE)), yes)
+    SRC += oled_display.c
+endif
 SRC += led_test_init.c
 
 # convert Helix-specific options (that represent combinations of standard options)

--- a/keyboards/helix/rev2/local_features.mk
+++ b/keyboards/helix/rev2/local_features.mk
@@ -32,65 +32,68 @@ define HELIX_HELP_MSG
 endef
 
   ifneq ($(strip $(HELIX)),)
+    define HELIX_OPTION_PARSE
+      # parce 'oled' 'back' 'under' 'ios' etc.
+      $(if $(SHOW_PARCE),$(info parse .$1.))  #debug
+
+      ifeq ($(strip $1),help)
+        HELP=on
+      endif
+      ifneq ($(filter nooled no-oled,$(strip $1)),)
+        OLED_ENABLE = no
+      endif
+      ifeq ($(strip $1),oled)
+        OLED_ENABLE = yes
+      endif
+      ifneq ($(filter noback no-back nounder no-under,$(strip $1)),)
+        LED_BACK_ENABLE = no
+        LED_UNDERGLOW_ENABLE = no
+      endif
+      ifeq ($(strip $1),back)
+        LED_BACK_ENABLE = yes
+        LED_UNDERGLOW_ENABLE = no
+      endif
+      ifeq ($(strip $1),under)
+        LED_BACK_ENABLE = no
+        LED_UNDERGLOW_ENABLE = yes
+      endif
+      ifneq ($(filter na no_ani no-ani,$(strip $1)),)
+        LED_ANIMATIONS = no
+      endif
+      ifeq ($(strip $1),ios)
+        IOS_DEVICE_ENABLE = yes
+      endif
+      ifneq ($(filter sc split-common split_common,$(strip $1)),)
+        SPLIT_KEYBOARD = yes
+      endif
+      ifneq ($(filter nosc no-sc no-split-common no-split_common,$(strip $1)),)
+        SPLIT_KEYBOARD = no
+      endif
+      ifeq ($(strip $1),scan)
+        # use DEBUG_MATRIX_SCAN_RATE
+        # see docs/newbs_testing_debugging.md
+        OPT_DEFS +=  -DDEBUG_MATRIX_SCAN_RATE
+        CONSOLE_ENABLE = yes
+        SHOW_VERBOSE_INFO = yes
+      endif
+      ifeq ($(strip $1),verbose)
+        SHOW_VERBOSE_INFO = yes
+      endif
+      ifeq ($(strip $1),lto)
+        LTO_ENABLE = yes
+      endif
+      ifneq ($(filter nolto no-lto no_lto,$(strip $1)),)
+        LTO_ENABLE = no
+      endif
+    endef # end of HELIX_OPTION_PARSE
+
     COMMA=,
-    helix_option := $(subst $(COMMA), , $(HELIX))
-    ifneq ($(filter help,$(helix_option)),)
-      $(eval $(call HELIX_HELP_MSG))
-      $(error )
-    endif
-    ifneq ($(filter nooled,$(helix_option)),)
-      OLED_ENABLE = no
-    else ifneq ($(filter no-oled,$(helix_option)),)
-      OLED_ENABLE = no
-    else ifneq ($(filter oled,$(helix_option)),)
-      OLED_ENABLE = yes
-    endif
-    ifneq ($(filter noback,$(helix_option)),)
-      LED_BACK_ENABLE = no
-      LED_UNDERGLOW_ENABLE = no
-    else ifneq ($(filter no-back,$(helix_option)),)
-      LED_BACK_ENABLE = no
-      LED_UNDERGLOW_ENABLE = no
-    else ifneq ($(filter nounder,$(helix_option)),)
-      LED_BACK_ENABLE = no
-      LED_UNDERGLOW_ENABLE = no
-    else ifneq ($(filter no-under,$(helix_option)),)
-      LED_BACK_ENABLE = no
-      LED_UNDERGLOW_ENABLE = no
-    else ifneq ($(filter back,$(helix_option)),)
-      LED_BACK_ENABLE = yes
-      LED_UNDERGLOW_ENABLE = no
-    else ifneq ($(filter under,$(helix_option)),)
-      LED_BACK_ENABLE = no
-      LED_UNDERGLOW_ENABLE = yes
-    endif
-    ifneq ($(filter na,$(helix_option)),)
-      LED_ANIMATIONS = no
-    endif
-    ifneq ($(filter no_ani,$(helix_option)),)
-      LED_ANIMATIONS = no
-    endif
-    ifneq ($(filter no-ani,$(helix_option)),)
-      LED_ANIMATIONS = no
-    endif
-    ifneq ($(filter ios,$(helix_option)),)
-      IOS_DEVICE_ENABLE = yes
-    endif
-    ifneq ($(filter sc,$(helix_option)),)
-      SPLIT_KEYBOARD = yes
-    endif
-    ifneq ($(filter split-common,$(helix_option)),)
-      SPLIT_KEYBOARD = yes
-    endif
-    ifneq ($(filter scan,$(helix_option)),)
-      # use DEBUG_MATRIX_SCAN_RATE
-      # see docs/newbs_testing_debugging.md
-      OPT_DEFS +=  -DDEBUG_MATRIX_SCAN_RATE
-      CONSOLE_ENABLE = yes
-      SHOW_VERBOSE_INFO = yes
-    endif
-    ifeq ($(filter verbose,$(helix_option)), verbose)
-      SHOW_VERBOSE_INFO = yes
+    $(eval $(foreach A_OPTION_NAME,$(subst $(COMMA), ,$(HELIX)),  \
+        $(call HELIX_OPTION_PARSE,$(A_OPTION_NAME))))
+
+    ifeq ($(strip $(HELP)),on)
+       $(eval $(call HELIX_HELP_MSG))
+       $(error )
     endif
     SHOW_HELIX_OPTIONS = yes
   endif

--- a/keyboards/helix/rev2/local_features.mk
+++ b/keyboards/helix/rev2/local_features.mk
@@ -10,6 +10,7 @@ KEYBOARD_LOCAL_FEATURES_MK :=
 define HELIX_CUSTOMISE_MSG
   $(info Helix Spacific Build Options)
   $(info -  OLED_ENABLE          = $(OLED_ENABLE))
+  $(info -  OLED_SELECT          = $(OLED_SELECT))
   $(info -  LED_BACK_ENABLE      = $(LED_BACK_ENABLE))
   $(info -  LED_UNDERGLOW_ENABLE = $(LED_UNDERGLOW_ENABLE))
   $(info -  LED_ANIMATIONS       = $(LED_ANIMATIONS))
@@ -20,9 +21,10 @@ endef
 define HELIX_HELP_MSG
   $(info Helix keyboard convenient command line option)
   $(info -    make HELIX=<options> helix:<keymap>)
-  $(info -    option= oled | no-oled | back | no-back | under | na | no-ani)
-  $(info -             ios | sc | split-common | scan | verbose)
-  $(info -    ex.)
+  $(info -    option= oled | core-oled | local-oled | no-oled )
+  $(info -            back | no-back   | under      | na   | no-ani )
+  $(info -             ios | sc        | split-common | scan | verbose)
+  $(info -    eg.)
   $(info -      make HELIX=no-oled       helix:<keymap>)
   $(info -      make HELIX=oled,no-back  helix:<keymap>)
   $(info -      make HELIX=oled,under    helix:<keymap>)
@@ -44,6 +46,14 @@ endef
       endif
       ifeq ($(strip $1),oled)
         OLED_ENABLE = yes
+      endif
+      ifneq ($(filter core-oled core_oled newoled new-oled olednew oled-new,$(strip $1)),)
+        OLED_ENABLE = yes
+        OLED_SELECT = core
+      endif
+      ifneq ($(filter local-oled local_oled oldoled old-oled oledold oled-old,$(strip $1)),)
+        OLED_ENABLE = yes
+        OLED_SELECT = local
       endif
       ifneq ($(filter noback no-back nounder no-under,$(strip $1)),)
         LED_BACK_ENABLE = no
@@ -145,12 +155,21 @@ ifeq ($(strip $(LED_ANIMATIONS)), yes)
 endif
 
 ifeq ($(strip $(OLED_ENABLE)), yes)
-    SRC += local_drivers/i2c.c
-    SRC += local_drivers/ssd1306.c
-    KEYBOARD_PATHS += $(HELIX_TOP_DIR)/local_drivers
-    OPT_DEFS += -DOLED_ENABLE
-    ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
-        OPT_DEFS += -DLOCAL_GLCDFONT
+    ifeq ($(strip $(OLED_SELECT)),core)
+        OLED_DRIVER_ENABLE = yes
+        ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+           OPT_DEFS += -DOLED_FONT_H=\<helixfont.h\>
+        else
+           OPT_DEFS += -DOLED_FONT_H=\"common/glcdfont.c\"
+        endif
+    else
+        SRC += local_drivers/i2c.c
+        SRC += local_drivers/ssd1306.c
+        KEYBOARD_PATHS += $(HELIX_TOP_DIR)/local_drivers
+        OPT_DEFS += -DOLED_ENABLE
+        ifeq ($(strip $(LOCAL_GLCDFONT)), yes)
+            OPT_DEFS += -DLOCAL_GLCDFONT
+        endif
     endif
 endif
 

--- a/keyboards/helix/rev2/rev2.c
+++ b/keyboards/helix/rev2/rev2.c
@@ -18,13 +18,30 @@ void led_set_kb(uint8_t usb_led) {
 }
 #endif
 
+bool is_mac_mode(void) {
+    // This is the opposite of the QMK standard, but we'll leave it for backwards compatibility.
+    return keymap_config.swap_lalt_lgui == false;
+}
+
+void set_mac_mode_kb(bool macmode) {
+    if (macmode) {
+        /* The result is the same as pressing the AG_NORM(=MAGIC_UNSWAP_ALT_GUI) key. */
+        /* https://github.com/qmk/qmk_firmware/blob/fb4a6ad30ea7a648acd59793ed4a30c3a8d8dc32/quantum/process_keycode/process_magic.c#L123-L124 */
+        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = false;
+    } else {
+        /* The result is the same as pressing the AG_SWAP(=MAGIC_SWAP_ALT_GUI) key. */
+        /* https://github.com/qmk/qmk_firmware/blob/fb4a6ad30ea7a648acd59793ed4a30c3a8d8dc32/quantum/process_keycode/process_magic.c#L80-L81 */
+        keymap_config.swap_lalt_lgui = keymap_config.swap_ralt_rgui = true;
+    }
+}
+
 void matrix_init_kb(void) {
     // Each keymap.c should use is_keyboard_master() instead of is_master.
     // But keep is_master for a while for backwards compatibility
     //  for the old keymap.c.
     is_master = is_keyboard_master();
 
-	matrix_init_user();
+    matrix_init_user();
 };
 
 void keyboard_post_init_kb(void) {

--- a/keyboards/helix/rev2/rev2.h
+++ b/keyboards/helix/rev2/rev2.h
@@ -2,6 +2,9 @@
 
 #include "helix.h"
 
+bool is_mac_mode(void);
+void set_mac_mode_kb(bool macmode);
+
 #ifndef SPLIT_KEYBOARD
     extern bool is_helix_master(void);
     #define is_keyboard_master() is_helix_master()

--- a/keyboards/helix/rev2/rules.mk
+++ b/keyboards/helix/rev2/rules.mk
@@ -8,3 +8,8 @@ LED_BACK_ENABLE = no        # LED backlight (Enable WS2812 RGB underlight.)
 LED_UNDERGLOW_ENABLE = no   # LED underglow (Enable WS2812 RGB underlight.)
 LED_ANIMATIONS = yes        # LED animations
 IOS_DEVICE_ENABLE = no      # connect to IOS device (iPad,iPhone)
+
+# If OLED_ENABLE is 'yes'
+#   If OLED_SELECT is 'core', use QMK standard oled_dirver.c.
+#   If OLED_SELECT is other than 'core', use helix/local_drivers/ssd1306.c.
+OLED_SELECT = local


### PR DESCRIPTION
## Description

Update keymap 'helix:default', 'helix:led_test'

* Makes the OLED driver used by the helix:default keymap switchable.
* Separated the OLED related code from keymap.c and moved it to oled_display.c.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
